### PR TITLE
use extended title at top of page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ColPrac: Collaborative Practices 
+# ColPrac: Contributor's Guide on Collaborative Practices for Community Packages
 
 This document describes some best practices for collaborating on repositories.
 Following these practices makes it easier for contributors (new and old) to understand what is expected of them.


### PR DESCRIPTION
The [website version](https://colprac.sciml.ai) doesn't show the description so including a expanded title at the top is better i think than just "ColPrac"