### PR TITLE
Updated README and make.jl to reflect new SciML docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ColPrac: Contributor's Guide on Collaborative Practices for Community Packages
 
+[![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/ColPrac/stable/)
+
 This document describes some best practices for collaborating on repositories.
 Following these practices makes it easier for contributors (new and old) to understand what is expected of them.
 It should be linked to in the README.md.
@@ -249,10 +251,6 @@ As mentioned at the top, community repositories following ColPrac, should link t
 One way to do that is with a GitHub badge.
 
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
-
-```markdown
-[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
-```
 
 In many-cases ColPrac serves in the places of a `CONTRIBUTING.md`, having all the common guidance that you would otherwise put there.
 If your package has its own `CONTRIBUTING.md` then you should also link to ColPrac there, and indicate how the contents of ColPrac relates to the `CONTRIBUTING.md`.

--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ One way to do that is with a GitHub badge.
 
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 
+```markdown
+[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
+```
+
 In many-cases ColPrac serves in the places of a `CONTRIBUTING.md`, having all the common guidance that you would otherwise put there.
 If your package has its own `CONTRIBUTING.md` then you should also link to ColPrac there, and indicate how the contents of ColPrac relates to the `CONTRIBUTING.md`.
 For example by stating:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,7 +17,7 @@ makedocs(sitename = "ColPrac",
          ],
          format = Documenter.HTML(analytics = "UA-90474609-3",
                                   assets = ["assets/favicon.ico"],
-                                  canonical = "https://colprac.sciml.ai/stable/"),
+                                  canonical = "https://docs.sciml.ai/ColPrac/stable/"),
          pages = [
              "ColPrac: Contributor's Guide on Collaborative Practices for Community Packages" => "index.md",
          ])


### PR DESCRIPTION
… badge at bottom or README.updated README and make.jl. Also removed duplicate Contributor's Guide…

Note that I set the doc links to "stable" and camelcase "ColPrac". We need to update the main SciML docs navigation link to reflect this new link.
