### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -10,22 +10,5 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: '1'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ --code-coverage=user docs/make.jl
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,9 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts ColPrac's CI to the centralized SciML reusable workflows (pinned `@v1`, every caller with `secrets: "inherit"`).

ColPrac is a meta/docs repo (empty `src/ColPrac.jl` module, empty `test/runtests.jl`), so per the centralization policy only the applicable checks are wired up — no Tests, no Downgrade callers were added.

### Converted (inline -> central caller)
- `Documentation.yml` -> `SciML/.github/.github/workflows/documentation.yml@v1`
- `FormatCheck.yml` (Runic, `fredrikekre/runic-action`) -> `runic.yml@v1`
- `SpellCheck.yml` (`crate-ci/typos`) -> `spellcheck.yml@v1`

Each workflow keeps its existing `name:` and `on:` triggers; each caller gets `secrets: "inherit"`.

### Cleanup
- Removed the `crate-ci/typos` ignore from `dependabot.yml` (typos now versioned via the central spellcheck workflow). The `github-actions` (weekly) and `julia` (daily, all-julia-packages) blocks are preserved.

### Added
- None (no Tests/Downgrade/Downstream/Benchmark applicable for this meta repo).

### Checks
- Runic: ran `Runic.main(["--inplace","."])` locally — no formatting changes needed (the only `.jl` files are trivial).
- Typos: ran `typos -w .` then `typos .` — 0 findings, no changes. **Typos fixed: 0.**

### Note on behavior differences
- The central documentation workflow uses `coverage-directories: "src,ext"` (default) and does not set `fail_ci_if_error: true`, whereas the previous inline workflow used `src` only with `fail_ci_if_error: true`. ColPrac has no `ext/`, so coverage scope is effectively unchanged; codecov no longer hard-fails the doc job on upload error.

### Warning
Check names change (e.g. job display names now come from the reusable workflows). Branch-protection required-status-check names will need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)