### PR TITLE
Restore contents:write permission for docs deploy (fix gh-pages 403)

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -10,5 +10,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
     uses: "SciML/.github/.github/workflows/documentation.yml@v1"
     secrets: "inherit"


### PR DESCRIPTION
## Problem

The docs **build** passes, but the `deploydocs` push to `gh-pages` fails (403 / "Permission denied" / `GITHUB_TOKEN` cannot push).

## Root cause

The CI-centralization migration dropped the `permissions:` block from the `build` caller job in `.github/workflows/Documentation.yml`. The job calls the centralized reusable `SciML/.github/.github/workflows/documentation.yml@v1`, which declares **no** `permissions:` of its own. In GitHub Actions, when a reusable workflow declares no permissions, the **caller job's** permissions flow through to the `GITHUB_TOKEN` it receives. With no permissions block on the caller, that token defaults to read-only and cannot push to the `gh-pages` branch, so the deploy step 403s while the build itself looks green.

ColPrac uses the `GITHUB_TOKEN`-based deploy path (no `DOCUMENTER_KEY`); Documenter's `deploydocs` auto-uses `GITHUB_TOKEN` when `DOCUMENTER_KEY` is absent, so all that is needed is to grant the caller job write access.

## Fix

Add the `permissions:` block to the `build` caller job, mirroring the proven fix in [OrdinaryDiffEqOperatorSplitting.jl #90](https://github.com/SciML/OrdinaryDiffEqOperatorSplitting.jl/pull/90):

```yaml
jobs:
  build:
    permissions:
      actions: write
      contents: write
      statuses: write
    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
    secrets: "inherit"
```

## Verification

- YAML validated locally with `python3 -c "import yaml; yaml.safe_load(...)"`.
- The deploy itself can only be confirmed by a CI run on `master` (where the token has the granted scope on PRs from a fork it is still read-only by design). The change is correct by matching the proven #90 pattern: it restores exactly the permissions a `GITHUB_TOKEN`-based `deploydocs` needs to push to `gh-pages`.
- No docs check was disabled and `warnonly` was not set.

Please ignore until reviewed by @ChrisRackauckas