### PR TITLE
Revert per-repo docs permissions block (superseded by SciML/.github#102)

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -10,9 +10,5 @@ on:
 
 jobs:
   build:
-    permissions:
-      actions: write
-      contents: write
-      statuses: write
     uses: "SciML/.github/.github/workflows/documentation.yml@v1"
     secrets: "inherit"


### PR DESCRIPTION
Per @ChrisRackauckas: revert the per-repo docs `permissions` block now that **SciML/.github#102** sets it centrally in the `documentation.yml` reusable. Pure cleanup so there's a single source of truth.

⚠️ **Merge ONLY after #102 is merged + `v1` retagged** — until then this repo's block is what keeps the gh-pages deploy working; reverting before #102 is live would 403 again.

Please ignore until reviewed by @ChrisRackauckas.